### PR TITLE
Participate in the Digital Analytics Program

### DIFF
--- a/site/_includes/footer.html
+++ b/site/_includes/footer.html
@@ -125,5 +125,8 @@
     ga('set', 'anonymizeIp', true);
     ga('send', 'pageview');
   </script>
+  
+  <!-- This is all it takes to report an agency's traffic to the DAP. -->
+  <script id="_fed_an_ua_tag" src="https://analytics.usa.gov/dap/dap.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This adds a snippet that links to the DAP. The URL to the snippet may need to be updated down the line, but right now there is no official public central hosting location for the DAP snippet.
