### PR TITLE
Specify no-magic so building works on linux machines

### DIFF
--- a/makefile
+++ b/makefile
@@ -6,7 +6,7 @@ all:
 	$(if $(shell if which s3cmd; then echo ok; fi), , $(error please install s3cmd))
 
 staging:
-	s3cmd put  --acl-public --exclude-from .s3ignore -r rendered/ $(staging_url)
+	s3cmd put  --no-mime-magic --acl-public --exclude-from .s3ignore -r rendered/ $(staging_url)
 
 production:
-	s3cmd put  --acl-public --add-header="Cache-Control:max-age=600" --exclude-from .s3ignore -r rendered/ $(production_url)
+	s3cmd put  --no-mime-magic --acl-public --add-header="Cache-Control:max-age=600" --exclude-from .s3ignore -r rendered/ $(production_url)


### PR DESCRIPTION
Linux machines often have `python-magic` present, which classifies css files as `text/plain`

See https://github.com/s3tools/s3cmd/issues/198
